### PR TITLE
[BIA-1291] Improve parquet file reuse

### DIFF
--- a/src/edfi_amt_data_lake/parquet/Common/pandasWrapper.py
+++ b/src/edfi_amt_data_lake/parquet/Common/pandasWrapper.py
@@ -210,12 +210,14 @@ def create_parquet_file(func) -> data_frame_generation_result:
             result_data_frame = get_data_frame_from_file(file_path=file_path)
             result = None
             if not (result_data_frame is None):
+                parquet_logger.debug(f'Read DataFrame {file_name} from file.')
                 result = data_frame_generation_result(
                     data_frame=result_data_frame,
                     columns=columns
                 )
                 return result
             else:
+                parquet_logger.debug(f'Create DataFrame {file_name} from script.')
                 result = data_frame_generation_result(
                     data_frame=func(file_name, columns, school_year),
                     columns=columns

--- a/src/edfi_amt_data_lake/parquet/amt/base/class_period_dim/main.py
+++ b/src/edfi_amt_data_lake/parquet/amt/base/class_period_dim/main.py
@@ -88,12 +88,12 @@ def class_period_dim_data_frame(
     addColumnIfNotExists(result_data_frame, 'classPeriodReference.classPeriodName')
 
     result_data_frame["ClassPeriodKey"] = (
-        result_data_frame["classPeriodReference.classPeriodName"] + "-" +
-        result_data_frame["courseOfferingReference.localCourseCode"] + "-" +
-        result_data_frame["courseOfferingReference.schoolId"].astype(str) + "-" +
-        result_data_frame["courseOfferingReference.schoolYear"].astype(str) + "-" +
-        result_data_frame["sectionIdentifier"] + "-" +
-        result_data_frame["courseOfferingReference.sessionName"]
+        result_data_frame["classPeriodReference.classPeriodName"]
+        + "-" + result_data_frame["courseOfferingReference.localCourseCode"]
+        + "-" + result_data_frame["courseOfferingReference.schoolId"].astype(str)
+        + "-" + result_data_frame["courseOfferingReference.schoolYear"].astype(str)
+        + "-" + result_data_frame["sectionIdentifier"]
+        + "-" + result_data_frame["courseOfferingReference.sessionName"]
     )
 
     result_data_frame["SectionKey"] = (

--- a/src/edfi_amt_data_lake/parquet/amt/base/student_local_education_agency_dim/main.py
+++ b/src/edfi_amt_data_lake/parquet/amt/base/student_local_education_agency_dim/main.py
@@ -75,7 +75,7 @@ def student_local_education_agency_dataframe(
     school_year: int
 ) -> pd.DataFrame:
     parquet_logger = get_dagster_logger()
-    parquet_logger.debug(f'Start with file: {file_name}') 
+    parquet_logger.debug(f'Start with file: {file_name}')
     student_education_organization_association_content = getEndpointJson(ENDPOINT_STUDENT_EDUCATION_ORGANIZATION_ASSOCIATION, config('SILVER_DATA_LOCATION'), school_year)
     student_content = getEndpointJson(ENDPOINT_STUDENT, config('SILVER_DATA_LOCATION'), school_year)
     student_school_association_content = getEndpointJson(ENDPOINT_STUDENT_SCHOOL_ASSOCIATION, config('SILVER_DATA_LOCATION'), school_year)
@@ -97,7 +97,8 @@ def student_local_education_agency_dataframe(
         recordPrefix=None,
         errors='ignore'
     )
-    student_normalize = renameColumns(student_normalize,
+    student_normalize = renameColumns(
+        student_normalize,
         {
             'id': 'studentReferenceId',
             'studentUniqueId': 'StudentKey',
@@ -144,13 +145,13 @@ def student_local_education_agency_dataframe(
         suffixLeft='_student',
         suffixRight='_student_school_association'
     )
-    if student_normalize is None: 
+    if student_normalize is None:
         return None
     student_normalize = (
-            student_normalize[
-                student_normalize['exitWithdrawDateKey'] >= student_normalize['dateKey']
-            ]
-        )
+        student_normalize[
+            student_normalize['exitWithdrawDateKey'] >= student_normalize['dateKey']
+        ]
+    )
     ############################
     # LocalEducationAgency
     ############################
@@ -165,7 +166,8 @@ def student_local_education_agency_dataframe(
         recordPrefix=None,
         errors='ignore'
     )
-    local_education_agency_normalize = renameColumns(local_education_agency_normalize,
+    local_education_agency_normalize = renameColumns(
+        local_education_agency_normalize,
         {
             'id': 'localEducationAgencyReferenceId',
             'localEducationAgencyId': 'LocalEducationAgencyKey'
@@ -263,7 +265,7 @@ def student_local_education_agency_dataframe(
             index='studentEducationOrganizationAssociationReferenceId',
             columns='indicatorName',
             values='indicator'
-         )
+        )
     )
     for item in INDICATOR_LIST_MAP:
         student_edorg_association_indicator_normalize[item['destination']] = (
@@ -285,7 +287,7 @@ def student_local_education_agency_dataframe(
         suffixLeft='_studentEdOrgAssociation',
         suffixRight='_local_education_agency'
     )
-    if result_data_frame is None: 
+    if result_data_frame is None:
         return None
     ############################
     # student_education_organization_association
@@ -299,7 +301,7 @@ def student_local_education_agency_dataframe(
         suffixLeft='_studentEdOrgAssociation',
         suffixRight='_studentEdOrgAssociationIndicator'
     )
-    if result_data_frame is None: 
+    if result_data_frame is None:
         return None
     ############################
     # student_education_organization_association
@@ -313,9 +315,9 @@ def student_local_education_agency_dataframe(
         suffixLeft='_studentEdOrgAssociation',
         suffixRight='_student'
     )
-    if result_data_frame is None: 
+    if result_data_frame is None:
         return None
-    
+
     result_data_frame['StudentLocalEducationAgencyKey'] = (
         result_data_frame['StudentKey']
         + '-' + result_data_frame['LocalEducationAgencyKey']

--- a/src/edfi_amt_data_lake/parquet/amt/base/student_school_demographics_bridge/main.py
+++ b/src/edfi_amt_data_lake/parquet/amt/base/student_school_demographics_bridge/main.py
@@ -6,8 +6,9 @@
 from datetime import date
 
 import pandas as pd
-from decouple import config
 from dagster import get_dagster_logger
+from decouple import config
+
 from edfi_amt_data_lake.helper.data_frame_generation_result import (
     data_frame_generation_result,
 )
@@ -41,7 +42,7 @@ def student_school_demographics_bridge_data_frame(
     school_year: int
 ) -> pd.DataFrame:
     parquet_logger = get_dagster_logger()
-    parquet_logger.debug(f'Start with file: {file_name}')    
+    parquet_logger.debug(f'Start with file: {file_name}')
     student_school_association_content = getEndpointJson(ENDPOINT_STUDENT_SCHOOL_ASSOCIATION, config('SILVER_DATA_LOCATION'), school_year)
     student_education_organization_association_content = getEndpointJson(ENDPOINT_STUDENT_EDUCATION_ORGANIZATION_ASSOCIATION, config('SILVER_DATA_LOCATION'), school_year)
     demographics_dictionary_list = [
@@ -143,8 +144,8 @@ def student_school_demographics_bridge_data_frame(
             demographics_data_frame = (
                 pd_concat(
                     [
-                        demographics_data_frame, 
-                        result_demographics,                                                       
+                        demographics_data_frame,
+                        result_demographics,
                     ]
                 )
             )
@@ -175,20 +176,20 @@ def student_school_demographics_bridge_data_frame(
             )
             result_data_frame = (
                 result_data_frame[
-                result_data_frame['exitWithdrawDateKey'] >= result_data_frame['dateKey']
+                    result_data_frame['exitWithdrawDateKey'] >= result_data_frame['dateKey']
                 ]
             )
         else:
             return None
     else:
         return None
-    # Select needed columns.    
-    result_data_frame = subset(result_data_frame, columns)    
+    # Select needed columns.
+    result_data_frame = subset(result_data_frame, columns)
     return result_data_frame
 
 
 def get_student_demographic(content, item) -> pd.DataFrame:
-    parquet_logger = get_dagster_logger()
+    get_dagster_logger()
     student_education_organization_association_content = content
     path = item['path']
     derived_path = item['derived_path'] if 'derived_path' in item else ''
@@ -259,7 +260,11 @@ def get_student_demographic(content, item) -> pd.DataFrame:
         recordPrefix='descriptor_',
         errors='ignore'
     )
-    student_demographic_descriptor_normalize.loc[student_demographic_descriptor_normalize[f'descriptor_{item["descriptor"]}'].isnull(),f'descriptor_{item["descriptor"]}'] = '' 
+    student_demographic_descriptor_normalize.loc[
+        student_demographic_descriptor_normalize[
+            f'descriptor_{item["descriptor"]}'
+        ].isnull(), f'descriptor_{item["descriptor"]}'
+    ] = ''
     # Get Descriptor
     get_descriptor_code_value_from_uri(
         student_demographic_descriptor_normalize,
@@ -276,7 +281,7 @@ def get_student_demographic(content, item) -> pd.DataFrame:
         student_demographic_descriptor_normalize,
         'prefix',
         item['prefix']
-    )        
+    )
     student_demographic_descriptor_normalize = (
         student_demographic_descriptor_normalize[
             'descriptorCodeValue' in student_demographic_descriptor_normalize
@@ -315,10 +320,11 @@ def get_student_demographic(content, item) -> pd.DataFrame:
         if derived_path != '':
             derived_column = f'descriptor_{derived_path}'
             student_demographic_descriptor_normalize_derived = student_demographic_descriptor_normalize.copy()
-            student_demographic_descriptor_normalize_derived[derived_column] =  student_demographic_descriptor_normalize[derived_column].explode().apply(pd.Series)
+            student_demographic_descriptor_normalize_derived[derived_column] = student_demographic_descriptor_normalize[derived_column].explode().apply(pd.Series)
             student_demographic_descriptor_normalize_derived.loc[
-                student_demographic_descriptor_normalize_derived[derived_column].isnull(),derived_column
-            ] = '' 
+                student_demographic_descriptor_normalize_derived[derived_column].isnull(),
+                derived_column
+            ] = ''
             # Get Descriptor
             get_descriptor_code_value_from_uri(
                 student_demographic_descriptor_normalize_derived,
@@ -355,7 +361,7 @@ def get_student_demographic(content, item) -> pd.DataFrame:
         suffixLeft=None,
         suffixRight=None
     )
-    
+
     student_demographic_normalize['SchoolKey'] = student_demographic_normalize['SchoolKey'].astype(str)
     if prefix == 'CohortYear':
         student_demographic_normalize['DemographicKey'] = (

--- a/src/edfi_amt_data_lake/parquet/amt/base/student_school_dim/main.py
+++ b/src/edfi_amt_data_lake/parquet/amt/base/student_school_dim/main.py
@@ -9,7 +9,7 @@ from edfi_amt_data_lake.helper.data_frame_generation_result import (
     data_frame_generation_result,
 )
 from edfi_amt_data_lake.parquet.amt.base.all_student_school_dim.main import (
-    all_student_school_dim_data_frame_base,
+    all_student_school_dim,
 )
 from edfi_amt_data_lake.parquet.Common.pandasWrapper import create_parquet_file
 
@@ -43,39 +43,10 @@ def student_school_dim_data_frame(
 ) -> pd.DataFrame:
     file_name = file_name
 
-    all_student_school_dim_columns = [
-        'AllStudentSchoolKey',
-        'StudentSchoolKey',
-        'StudentKey',
-        'SchoolKey',
-        'SchoolYear',
-        'StudentFirstName',
-        'StudentMiddleName',
-        'StudentLastName',
-        'BirthDate',
-        'EnrollmentDateKey',
-        'GradeLevel',
-        'LimitedEnglishProficiency',
-        'IsHispanic',
-        'Sex',
-        'InternetAccessInResidence',
-        'InternetAccessTypeInResidence',
-        'InternetPerformance',
-        'DigitalDevice',
-        'DeviceAccess',
-        'IsEnrolled',
-        'ExitWithdrawDate'
-    ]
-
-
-    result_data_frame = all_student_school_dim_data_frame_base(
-        file_name=file_name,
-        columns=all_student_school_dim_columns,
-        school_year=school_year
-    )
-
+    result_data_frame = all_student_school_dim(school_year=school_year).data_frame
+    if result_data_frame is None:
+        return None
     result_data_frame = result_data_frame[result_data_frame['IsEnrolled'] == 1]
-
     return result_data_frame[
         columns
     ]

--- a/src/edfi_amt_data_lake/parquet/amt_parquet.py
+++ b/src/edfi_amt_data_lake/parquet/amt_parquet.py
@@ -36,6 +36,6 @@ def generate_amt_parquet(school_year) -> None:
     rls_collection(school_year)
     parquet_logger.info(
         '*************************************\n'
-        + f'* Finished Parquet Generation Process'
+        + f'* Finished Parquet Generation Process {school_year}'
         + '\n*************************************'
     )

--- a/src/edfi_amt_data_lake/parquet/amt_parquet.py
+++ b/src/edfi_amt_data_lake/parquet/amt_parquet.py
@@ -3,7 +3,9 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+from dagster import get_dagster_logger
 
+from edfi_amt_data_lake.helper.helper import clean_parquet_folder
 from edfi_amt_data_lake.parquet.amt.asmt.asmt_collection import asmt_collection
 from edfi_amt_data_lake.parquet.amt.base.base_collection import base_collection
 from edfi_amt_data_lake.parquet.amt.chrab.chrab_collection import chrab_collection
@@ -16,6 +18,13 @@ from edfi_amt_data_lake.parquet.amt.rls.rls_collection import rls_collection
 
 
 def generate_amt_parquet(school_year) -> None:
+    parquet_logger = get_dagster_logger()
+    parquet_logger.info(
+        '*************************************\n'
+        + f'* Start Parquet Generation {school_year}'
+        + '\n*************************************'
+    )
+    clean_parquet_folder(school_year)
     asmt_collection(school_year)
     base_collection(school_year)
     chrab_collection(school_year)
@@ -25,3 +34,8 @@ def generate_amt_parquet(school_year) -> None:
     ews_collection(school_year)
     qews_collection(school_year)
     rls_collection(school_year)
+    parquet_logger.info(
+        '*************************************\n'
+        + f'* Finished Parquet Generation Process'
+        + '\n*************************************'
+    )


### PR DESCRIPTION
- Add function to delete the old parquet files.
- Add function to read a parquet file from file instead of invoke the function to create the file.

To test this change you can use StudentSchoolDim and AllStudentSchoolDim and check in the debug log if the dataframe is created twice or the second time is loaded from disk.